### PR TITLE
Rename name output to fqdn.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Nullstone Block standing up a domain in AWS Route53.
 
 ## Outputs
 
-- `name: string` - Subdomain Name
+- `name: string` - The name of the created domain
+- `fqdn: string` - The FQDN (fully-qualified domain name) for the created domain
 - `zone_id: string` - Route53 Zone ID of Subdomain
 - `nameservers: list(string)` - List of Nameservers for Route53 Zone
 - `delegator: object({ name: string, access_key: string, secret_key: string })` 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,11 @@
 output "name" {
   value       = var.domain
-  description = "string ||| "
+  description = "string ||| The name of the created domain."
+}
+
+output "fqdn" {
+  value       = var.domain
+  description = "string ||| The FQDN (fully-qualified domain name) for the created domain."
 }
 
 output "zone_id" {


### PR DESCRIPTION
This PR renames the `name` output to `fqdn`.
The `name` output now refers to the input domain name.