### PR TITLE
C294 intro autogen subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Nullstone Block standing up a domain in AWS Route53.
 
 ## Variables
 
-- `domain: string` - Domain to configure a DNS zone
+None
 
 ## Outputs
 

--- a/domain.tf
+++ b/domain.tf
@@ -1,4 +1,9 @@
+data "ns_domain" "this" {
+  stack = data.ns_workspace.this.stack
+  block = data.ns_workspace.this.block
+}
+
 resource "aws_route53_zone" "this" {
-  name = var.domain
+  name = data.ns_domain.this.dns_name
   tags = data.ns_workspace.this.tags
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,10 @@
 output "name" {
-  value       = var.domain
+  value       = data.ns_domain.this.dns_name
   description = "string ||| The name of the created domain."
 }
 
 output "fqdn" {
-  value       = var.domain
+  value       = data.ns_domain.this.dns_name
   description = "string ||| The FQDN (fully-qualified domain name) for the created domain."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,0 @@
-variable "domain" {
-  type        = string
-  description = "This represents the domain to create a DNS zone"
-}


### PR DESCRIPTION
This PR updates the module to pull the dns_name from nullstone (via the ns_domain terraform provider) instead of taking it in as a variable.